### PR TITLE
Add default referrer and switch to last-touch binding in AffiliateRouter

### DIFF
--- a/contracts/test/MockSwapManager.sol
+++ b/contracts/test/MockSwapManager.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interfaces/ISwapManager.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @dev Minimal mock that satisfies the interface and accepts any route bytes.
+contract MockSwapManager is ISwapManager {
+    // Dummy storage to satisfy interface getters (not used by tests)
+    mapping(string => address) private _dexRouters;
+    address private _affiliateRouter;
+    IWETH9 private _weth;
+
+    function dexRouters(string calldata k) external view override returns (address) {
+        return _dexRouters[k];
+    }
+    function affiliateRouter() external view override returns (address) {
+        return _affiliateRouter;
+    }
+    function weth() external view override returns (IWETH9) {
+        return _weth;
+    }
+
+    function initialize(address _aff) external override { _affiliateRouter = _aff; }
+    function setDexRouters(string[] calldata, address[] calldata) external override {}
+    function setAffiliateRouter(address _aff) external override { _affiliateRouter = _aff; }
+
+    // The router under test will call this with whatever remains after fees.
+    function executeSwap(bytes calldata /*routeBytes*/) external payable override {
+        // no-op
+    }
+
+    function rescueTokens(address token, address to) external override {
+        if (token == address(0)) {
+            (bool s,) = to.call{value: address(this).balance}("");
+            require(s, "eth xfer fail");
+        } else {
+            IERC20(token).transfer(to, IERC20(token).balanceOf(address(this)));
+        }
+    }
+
+    receive() external payable {}
+}

--- a/test/affiliateRouter.lastTouch.spec.ts
+++ b/test/affiliateRouter.lastTouch.spec.ts
@@ -1,0 +1,148 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { AbiCoder, ZeroAddress, parseEther } from "ethers";
+
+// Match ISwapManager.SwapRoute from your interfaces
+const SwapStep = "tuple(string dex,address[] path,address pool,uint256 percent,uint256 groupId,uint256 parentGroupId,bytes userData)";
+const Group = "tuple(uint256 id,uint256 percent)";
+const SwapRoute = `tuple(${SwapStep}[] steps, ${Group}[] parentGroups, address destination, address tokenIn, address tokenOut, uint256 groupCount, uint256 deadline, uint256 amountIn, uint256 amountOutMin)`;
+
+function encodeRoute(params: {
+  tokenIn: string;
+  amountIn: bigint;
+  amountOutMin?: bigint;
+  deadline?: number;
+}) {
+  const now = Math.floor(Date.now() / 1000);
+  const route = {
+    steps: [],
+    parentGroups: [],
+    destination: ZeroAddress,
+    tokenIn: params.tokenIn,
+    tokenOut: ZeroAddress,
+    groupCount: 0,
+    deadline: params.deadline ?? now + 3600,
+    amountIn: params.amountIn,
+    amountOutMin: params.amountOutMin ?? 0n,
+  };
+  const coder = AbiCoder.defaultAbiCoder();
+  return coder.encode([SwapRoute], [route]);
+}
+
+describe("AffiliateRouter - last-touch + default", () => {
+  it("binds default when no mapping and no explicit code", async () => {
+    const [owner, user, platform] = await ethers.getSigners();
+
+    const Mock = await ethers.getContractFactory("MockSwapManager");
+    const mock = await Mock.deploy();
+    await mock.waitForDeployment();
+
+    const Router = await ethers.getContractFactory("AffiliateRouter");
+    const router = await Router.deploy();
+    await router.waitForDeployment();
+    await router.initialize(await mock.getAddress());
+
+    // set default referrer
+    await (router as any).setDefaultReferrer(platform.address);
+
+    const amountIn = parseEther("1");
+    const routeBytes = encodeRoute({
+      tokenIn: ZeroAddress,
+      amountIn,
+    });
+
+    await expect(router.connect(user).executeSwap(routeBytes, ZeroAddress, { value: amountIn }))
+      .to.emit(router, "ReferralRegistered")
+      .withArgs(user.address, platform.address);
+
+    expect(await router.userReferrer(user.address)).to.eq(platform.address);
+  });
+
+  it("explicit code overwrites (last-touch)", async () => {
+    const [owner, user, A, B] = await ethers.getSigners();
+
+    const Mock = await ethers.getContractFactory("MockSwapManager");
+    const mock = await Mock.deploy();
+    await mock.waitForDeployment();
+
+    const Router = await ethers.getContractFactory("AffiliateRouter");
+    const router = await Router.deploy();
+    await router.waitForDeployment();
+    await router.initialize(await mock.getAddress());
+
+    await (router as any).setDefaultReferrer(A.address);
+
+    const amountIn = parseEther("1");
+    const routeBytes = encodeRoute({
+      tokenIn: ZeroAddress,
+      amountIn,
+    });
+
+    // First swap with no explicit -> binds default A
+    await router.connect(user).executeSwap(routeBytes, ZeroAddress, { value: amountIn });
+    expect(await router.userReferrer(user.address)).to.eq(A.address);
+
+    // Next swap with explicit B -> overwrite to B (last-touch)
+    await expect(router.connect(user).executeSwap(routeBytes, B.address, { value: amountIn }))
+      .to.emit(router, "ReferralRegistered")
+      .withArgs(user.address, B.address);
+
+    expect(await router.userReferrer(user.address)).to.eq(B.address);
+  });
+
+  it("ignores self-referral", async () => {
+    const [owner, user, plat] = await ethers.getSigners();
+
+    const Mock = await ethers.getContractFactory("MockSwapManager");
+    const mock = await Mock.deploy();
+    await mock.waitForDeployment();
+
+    const Router = await ethers.getContractFactory("AffiliateRouter");
+    const router = await Router.deploy();
+    await router.waitForDeployment();
+    await router.initialize(await mock.getAddress());
+
+    await (router as any).setDefaultReferrer(plat.address);
+
+    const amountIn = parseEther("1");
+    const routeBytes = encodeRoute({
+      tokenIn: ZeroAddress,
+      amountIn,
+    });
+
+    // Bind default
+    await router.connect(user).executeSwap(routeBytes, ZeroAddress, { value: amountIn });
+    expect(await router.userReferrer(user.address)).to.eq(plat.address);
+
+    // Try self-referral -> mapping stays platform
+    await router.connect(user).executeSwap(routeBytes, user.address, { value: amountIn });
+    expect(await router.userReferrer(user.address)).to.eq(plat.address);
+  });
+
+  it("credits fee to chosen referrer (ETH path)", async () => {
+    const [owner, user, ref] = await ethers.getSigners();
+
+    const Mock = await ethers.getContractFactory("MockSwapManager");
+    const mock = await Mock.deploy();
+    await mock.waitForDeployment();
+
+    const Router = await ethers.getContractFactory("AffiliateRouter");
+    const router = await Router.deploy();
+    await router.waitForDeployment();
+    await router.initialize(await mock.getAddress());
+
+    const amountIn = parseEther("2"); // 2 ETH
+    const routeBytes = encodeRoute({
+      tokenIn: ZeroAddress,
+      amountIn,
+    });
+
+    // Set explicit referrer
+    await router.connect(user).executeSwap(routeBytes, ref.address, { value: amountIn });
+
+    // Default fee bps is 10 (0.10%)
+    const fee = (amountIn * 10n) / 10000n;
+    const earned = await router.referrerEarnings(ref.address, ZeroAddress);
+    expect(earned).to.eq(fee);
+  });
+});


### PR DESCRIPTION
## Summary
Implements **last‑touch wins** referral binding and introduces a configurable **defaultReferrer** to ensure swaps without an explicit referrer still support the platform.

## What changed
- **AffiliateRouter.sol**
  - Added `address public defaultReferrer;`
  - Added owner‑only `setDefaultReferrer(address)` (zero address disables default)
  - **Changed referral binding logic in `executeSwap(...)`:**
    - If `referrerCode` is non‑zero and not self → (re)bind to that code (**last‑touch**)
    - Else if user has no referrer and `defaultReferrer` is set (and not self) → bind to default
  - **No other logic changed**: fee math, events, pausable, withdraw flow all unchanged

## Rationale
- **Revenue assurance:** When no code is present, swaps now credit the platform (via `defaultReferrer`).
- **More intuitive attribution:** Using **last‑touch** mirrors common analytics practice—new, explicit codes take precedence over older ones.
- **Minimal diff for review:** Only one storage variable and a small, localized change in `executeSwap`.

## Backwards compatibility
- Existing users **keep their current referrer** until they pass a new explicit `referrerCode` (which will overwrite per last‑touch).
- New users without a code will be bound to `defaultReferrer` on their first swap; previously they would remain unbound.

## Storage / Upgrade notes
- Appended **one** new storage slot (`defaultReferrer`) at the end of existing vars.
- Standard upgrade steps apply (compile, prepare upgrade, run storage layout checks; see CI).

## Security considerations
- Self‑referral still blocked (`referrer != msg.sender` checks preserved).
- `defaultReferrer` can be turned off by setting it to the zero address.
- No changes to token handling / approvals; swap path continues via `SwapManager` as before.

## Tests
Added unit tests (Hardhat, ethers v6):
- `binds default when no mapping and no explicit code`
- `explicit code overwrites (last‑touch)`
- `ignores self‑referral`
- `credits fee to chosen referrer (ETH path)`

**Files**
- `contracts/test/MockSwapManager.sol` — minimal ISwapManager mock
- `test/affiliateRouter.lastTouch.spec.ts` — route encoding + assertions

## Deployment
1. Deploy/upgrade `AffiliateRouter` implementation.
2. As owner, set the platform wallet:
   ```solidity
   router.setDefaultReferrer(<PLATFORM_ADDRESS>);
   ```
3. (Optional) Adjust `defaultFeeBasisPoints` if you want a different default fee (e.g., 300 for 3.00%).

## Todo
- these changes never tested, this contract needs to be deployed and tested, and the tests for it need to be run and tested